### PR TITLE
Fix frame extraction and expose video generation controls

### DIFF
--- a/app.py
+++ b/app.py
@@ -37,7 +37,7 @@ FRAME_DIR.mkdir(parents=True, exist_ok=True)
 
 DEFAULT_VIDEO_SIZE = "1280x720"
 DEFAULT_SECONDS = 8
-ALLOWED_SECONDS = [4, 8, 12]
+ALLOWED_SECONDS = [4, 8, 12, 24]
 
 OPENAI_API_BASE = "https://api.openai.com/v1"
 SORA_VIDEOS_ENDPOINT = f"{OPENAI_API_BASE}/videos"
@@ -86,6 +86,7 @@ class CreateSessionRequest(BaseModel):
     planner_model: str = Field(..., alias="plannerModel")
     sora_model: str = Field(..., alias="soraModel")
     video_size: str = Field(DEFAULT_VIDEO_SIZE, alias="videoSize")
+    video_seconds: int = Field(DEFAULT_SECONDS, alias="videoSeconds")
     base_prompt: str = Field(..., alias="basePrompt")
     max_steps: int = Field(10, alias="maxSteps")
 
@@ -93,6 +94,12 @@ class CreateSessionRequest(BaseModel):
     def validate_max_steps(cls, value: int) -> int:
         if not 1 <= value <= 30:
             raise ValueError("maxSteps must be between 1 and 30")
+        return value
+
+    @validator("video_seconds")
+    def validate_video_seconds(cls, value: int) -> int:
+        if value <= 0:
+            raise ValueError("videoSeconds must be positive")
         return value
 
 
@@ -133,6 +140,7 @@ class SessionConfig:
     planner_model: str
     sora_model: str
     video_size: str
+    video_seconds: int
     base_prompt: str
     max_steps: int
 
@@ -476,6 +484,7 @@ def sora_poll_until_complete(api_key: str, job: dict) -> dict:
 
 
 def extract_last_frame(video_path: Path, out_image_path: Path) -> Path:
+    out_image_path.parent.mkdir(parents=True, exist_ok=True)
     if cv2 is not None:
         cap = cv2.VideoCapture(str(video_path))
         if cap.isOpened():
@@ -626,6 +635,7 @@ def create_session(payload: CreateSessionRequest) -> SessionResponse:
         planner_model=payload.planner_model.strip() or "gpt-5",
         sora_model=payload.sora_model.strip() or "sora-2",
         video_size=payload.video_size.strip() or DEFAULT_VIDEO_SIZE,
+        video_seconds=normalize_seconds(payload.video_seconds),
         base_prompt=payload.base_prompt.strip(),
         max_steps=payload.max_steps,
     )
@@ -653,7 +663,7 @@ def create_session(payload: CreateSessionRequest) -> SessionResponse:
                 sora_prompt=story_item["sora_prompt"],
                 model=config.sora_model,
                 size=config.video_size,
-                seconds=DEFAULT_SECONDS,
+                seconds=config.video_seconds,
                 input_reference=None,
             )
             story_item["video_id"] = video_id
@@ -730,7 +740,7 @@ def advance_story(session_id: str, payload: ChoiceRequest) -> SessionResponse:
                     sora_prompt=next_item["sora_prompt"],
                     model=state.config.sora_model,
                     size=state.config.video_size,
-                    seconds=DEFAULT_SECONDS,
+                    seconds=state.config.video_seconds,
                     input_reference=input_reference,
                 )
                 next_item["video_id"] = video_id

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -31,6 +31,8 @@ const App = () => {
         plannerModel: config.plannerModel,
         soraModel: config.soraModel,
         videoSize: config.videoSize,
+        videoSeconds: Number(config.videoSeconds) || 8,
+        maxSteps: Number(config.maxSteps) || 10,
         basePrompt: config.basePrompt,
       };
       const { data } = await api.post("/api/session", payload);

--- a/frontend/src/components/ConfigScreen.jsx
+++ b/frontend/src/components/ConfigScreen.jsx
@@ -25,6 +25,8 @@ const ConfigScreen = ({ onSubmit, isSubmitting, error, apiBaseUrl }) => {
     plannerModel: "gpt-5",
     soraModel: "sora-2",
     videoSize: "1280x720",
+    videoSeconds: 8,
+    maxSteps: 10,
     basePrompt:
       "A cozy fantasy village at dusk, with glowing lanterns, narrow cobblestone streets, and a mysterious whisper about an ancient forest relic.",
   });
@@ -44,7 +46,8 @@ const ConfigScreen = ({ onSubmit, isSubmitting, error, apiBaseUrl }) => {
 
   const handleChange = (event) => {
     const { name, value } = event.target;
-    setForm((prev) => ({ ...prev, [name]: value }));
+    const nextValue = event.target.type === "number" ? Number(value) : value;
+    setForm((prev) => ({ ...prev, [name]: nextValue }));
     if (name === "apiKey" && typeof window !== "undefined") {
       window.localStorage.setItem("sora_cyoa_api_key", value);
     }
@@ -138,6 +141,26 @@ const ConfigScreen = ({ onSubmit, isSubmitting, error, apiBaseUrl }) => {
                     <option value="1920x1080">1920 × 1080</option>
                     <option value="720x1280">720 × 1280</option>
                   </select>
+                </label>
+                <label className="field">
+                  <span>Clip duration (seconds)</span>
+                  <select name="videoSeconds" value={form.videoSeconds} onChange={handleChange}>
+                    <option value={4}>4s</option>
+                    <option value={8}>8s</option>
+                    <option value={12}>12s</option>
+                    <option value={24}>24s</option>
+                  </select>
+                </label>
+                <label className="field">
+                  <span>Follow-up scenes (max)</span>
+                  <input
+                    name="maxSteps"
+                    type="number"
+                    min={1}
+                    max={30}
+                    value={form.maxSteps}
+                    onChange={handleChange}
+                  />
                 </label>
               </div>
 


### PR DESCRIPTION
## Summary
- ensure last-frame extraction creates missing parent folders before writing
- allow configuring clip duration (including 24s) and follow-up scene count via the session API and config UI

## Testing
- python -m compileall app.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c4afa7fa883279461ddcd84a36170)